### PR TITLE
Fix runNUMBER env var problem

### DIFF
--- a/solid/templates/rosim.sh
+++ b/solid/templates/rosim.sh
@@ -70,9 +70,9 @@ mv december2017-baselines.root baselines.root
 /cvmfs/solidexperiment.egi.eu/el6/saffron2/${Version}/saffron2/saffron {{macro}} --RunNumber={{ ro_runNumber }} --AppendInputFiles=${inputfile} &> log.txt
 #/cvmfs/solidexperiment.egi.eu/el6/saffron2/v1.2/saffron2/saffron onlineMonitoringBR2.txt --RunNumber=1002808 --AppendInputFiles=rundetector_1002808_06Dec17_1908.sbf
 
-dirac-dms-add-file {{ ro_output_lfndir }}/histos/S2-histos_cycleMode_${jobnumber}_$runNUMBER_{{ id }}.root S2-histos_cycleMode.root UKI-LT2-IC-HEP-disk
-dirac-dms-add-file {{ ro_output_lfndir }}/ntuples/S2-tuple_${jobnumber}_$runNUMBER_{{ id }}.root S2-tuple.root UKI-LT2-IC-HEP-disk
-dirac-dms-add-file {{ ro_output_lfndir }}/logs/log_${jobnumber}_$runNUMBER_{{ id }}.txt log.txt UKI-LT2-IC-HEP-disk
+dirac-dms-add-file {{ ro_output_lfndir }}/histos/S2-histos_cycleMode_${jobnumber}_${runNUMBER}_{{ id }}.root S2-histos_cycleMode.root UKI-LT2-IC-HEP-disk
+dirac-dms-add-file {{ ro_output_lfndir }}/ntuples/S2-tuple_${jobnumber}_${runNUMBER}_{{ id }}.root S2-tuple.root UKI-LT2-IC-HEP-disk
+dirac-dms-add-file {{ ro_output_lfndir }}/logs/log_${jobnumber}_${runNUMBER}_{{ id }}.txt log.txt UKI-LT2-IC-HEP-disk
 
 #dirac-dms-add-file /solidexperiment.org/Data/phase1_BR2/test/test_grid/S2-histos_cycleMode_${jobnumber}_$runNUMBER.root S2-histos_cycleMode.root UKI-LT2-IC-HEP-disk
 #dirac-dms-add-file /solidexperiment.org/Data/phase1_BR2/test/test_grid/S2_${jobnumber}_$runNUMBER.root S2-tuple.root UKI-LT2-IC-HEP-disk

--- a/solid/templates/runscript.sh
+++ b/solid/templates/runscript.sh
@@ -76,9 +76,9 @@ inputfile=${inputfile%.bz2}
 /cvmfs/solidexperiment.egi.eu/el6/saffron2/${Version}/saffron2/saffron {{macro}} --RunNumber=$runNUMBER --AppendInputFiles=${inputfile} &> log.txt
 #/cvmfs/solidexperiment.egi.eu/el6/saffron2/v1.2/saffron2/saffron onlineMonitoringBR2.txt --RunNumber=1002808 --AppendInputFiles=rundetector_1002808_06Dec17_1908.sbf
 
-dirac-dms-add-file {{ analysis_output_lfndir }}/histos/S2-histos_cycleMode_${jobnumber}_$runNUMBER_$runTime.root S2-histos_cycleMode.root UKI-LT2-IC-HEP-disk
-dirac-dms-add-file {{ analysis_output_lfndir }}/ntuples/S2-tuple_${jobnumber}_$runNUMBER_$runTime.root S2-tuple.root UKI-LT2-IC-HEP-disk
-dirac-dms-add-file {{ analysis_output_lfndir }}/logs/log_${jobnumber}_$runNUMBER_$runTime.txt log.txt UKI-LT2-IC-HEP-disk
+dirac-dms-add-file {{ analysis_output_lfndir }}/histos/S2-histos_cycleMode_${jobnumber}_${runNUMBER}_$runTime.root S2-histos_cycleMode.root UKI-LT2-IC-HEP-disk
+dirac-dms-add-file {{ analysis_output_lfndir }}/ntuples/S2-tuple_${jobnumber}_${runNUMBER}_$runTime.root S2-tuple.root UKI-LT2-IC-HEP-disk
+dirac-dms-add-file {{ analysis_output_lfndir }}/logs/log_${jobnumber}_${runNUMBER}_$runTime.txt log.txt UKI-LT2-IC-HEP-disk
 
 #dirac-dms-add-file /solidexperiment.org/Data/phase1_BR2/test/test_grid/S2-histos_cycleMode_${jobnumber}_$runNUMBER.root S2-histos_cycleMode.root UKI-LT2-IC-HEP-disk
 #dirac-dms-add-file /solidexperiment.org/Data/phase1_BR2/test/test_grid/S2_${jobnumber}_$runNUMBER.root S2-tuple.root UKI-LT2-IC-HEP-disk


### PR DESCRIPTION
The env var `runNUMBER` was including the extra underscore such that it was being parsed as `runNUMBER_`